### PR TITLE
Fix fork creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -107,6 +107,16 @@ class Manager
             );
             $taskProcess = new Process($task->getCommandToExecute());
             $taskProcess->start();
+
+            // Give a little time to fork process
+            usleep(5000);
+
+            $this->getLogger()->info(
+                sprintf('Cron task "%s" started with pid %s', $task->getName(), $taskProcess->getPid()),
+                array(
+                    'command' => $task->getCommandToExecute()
+                )
+            );
         }
     }
 

--- a/Tests/Command/CronRunCommandTest.php
+++ b/Tests/Command/CronRunCommandTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Symfony\Component\Console\Application;
+use ADR\Bundle\CassandraBundle\Command\CassandraCreateKeyspaceCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Mockery as m;
+
+use Sbk\Bundle\CronBundle\Command\CronRunCommand;
+use Sbk\Bundle\CronBundle\Cron\Manager;
+
+class CronRunCommandTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testExecution()
+    {
+
+        $tmp_file_1 = sys_get_temp_dir().'/CronRunCommandTest-testExecution-1.txt';
+        $tmp_file_2 = sys_get_temp_dir().'/CronRunCommandTest-testExecution-2.txt';
+        $this->removeFileIfExists($tmp_file_1);
+        $this->removeFileIfExists($tmp_file_2);
+        
+        $tasksConfig = array(
+            'ls_task' => array(
+                'bin' => 'ls',
+                'command' => '-l > '.$tmp_file_1,
+                'expression' => '* * * * *',
+            ),
+            'df_task' => array(
+                'bin' => 'df',
+                'command' => '-h > '.$tmp_file_2,
+                'expression' => '* * * * *',
+            ),
+        );
+        
+        $application = new Application();
+        $application->add(new CronRunCommand());
+
+        $command = $application->find('cron:run');
+        $command->setContainer($this->getMockContainer($tasksConfig));
+
+        $tester = new CommandTester($command);
+        $tester->execute(
+            array('command' => $command->getName())
+        );
+
+        $this->assertTrue(file_exists($tmp_file_1), 'Test if file #1 has been created by task through cron:run');
+        $this->assertTrue(file_exists($tmp_file_2), 'Test if file #2 has been created by task through cron:run');
+
+        $this->removeFileIfExists($tmp_file_1);
+        $this->removeFileIfExists($tmp_file_2);
+
+    }
+
+    private function getMockContainer($tasksConfig)
+    {
+        $logger = m::mock('Monolog\Logger', array('phpunit'))->makePartial();
+
+        $cronManager = new Manager($logger, 'console', $tasksConfig);
+ 
+        $container = m::mock('Symfony\Component\DependencyInjection\Container');
+        $container
+            ->shouldReceive('get')
+            ->once()
+            ->with('sbk_cron.manager')
+            ->andReturn($cronManager)
+        ;
+ 
+        return $container;
+    }
+
+    /**
+     * @param  string $file
+     * @return
+     */
+    private function removeFileIfExists($file)
+    {
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/options-resolver": "~2.1",
         "symfony/process": "~2.1",
         "symfony/console": "~2.1",
+        "mockery/mockery": "~0.9",
         "monolog/monolog": "~1.7.0"
     },
     "autoload": {


### PR DESCRIPTION
I had an issue when I executed cron:run with some symfony commands.
There was a trace in the log showing that the command had been started but in reality, it was not.

It seems that this was due to the fact that the script is terminating too fast, the fork does not have the time to start.

I don't have anymore problem with this fix : I've just added a microsleep with a few millisecs after `$process->start()`
